### PR TITLE
docs!: Improve error message for unsupported VCS platform (bug 1793219)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
   hooks:
   - id: flynt
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.1
+  rev: v2.2.2
   hooks:
   - id: codespell
 - repo: https://github.com/compilerla/conventional-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.1.0
+  rev: v3.2.0
   hooks:
   - id: pyupgrade
     args: [--py36-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,11 @@ repos:
   - id: trailing-whitespace
     args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 22.10.0
   hooks:
   - id: black
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.38.2
+  rev: v3.1.0
   hooks:
   - id: pyupgrade
     args: [--py36-plus]

--- a/mozilla_repo_urls/errors.py
+++ b/mozilla_repo_urls/errors.py
@@ -16,5 +16,5 @@ class UnsupportedPlatformError(RepoUrlsBaseError):
         self._supported_platforms = supported_platforms
         super().__init__(
             f"Unsupported version control host. Got: {host}. "
-            f"Expected one of: {supported_platforms}. URL: {url_string}"
+            f"Expected one of: {supported_hosts}. URL: {url_string}"
         )

--- a/mozilla_repo_urls/errors.py
+++ b/mozilla_repo_urls/errors.py
@@ -9,7 +9,6 @@ class InvalidRepoUrlError(RepoUrlsBaseError):
 
 class UnsupportedPlatformError(RepoUrlsBaseError):
     def __init__(self, url_string, host, supported_hosts) -> None:
-        self.supported_hosts = supported_hosts
         super().__init__(
             f"Unsupported version control host. Got: {host}. "
             f"Expected one of: {supported_hosts}. URL: {url_string}"

--- a/mozilla_repo_urls/errors.py
+++ b/mozilla_repo_urls/errors.py
@@ -8,8 +8,13 @@ class InvalidRepoUrlError(RepoUrlsBaseError):
 
 
 class UnsupportedPlatformError(RepoUrlsBaseError):
+    @property
+    def supported_platforms(self):
+        return list(self._supported_platforms)
+
     def __init__(self, url_string, platform, supported_platforms) -> None:
+        self._supported_platforms = supported_platforms
         super().__init__(
-            f"Unsupported platform. Got: {platform}. "
-            f"Expected: {supported_platforms}. URL: {url_string}"
+            f"Unsupported version control host. Got: {platform}. "
+            f"Expected one of: {supported_platforms}. URL: {url_string}"
         )

--- a/mozilla_repo_urls/errors.py
+++ b/mozilla_repo_urls/errors.py
@@ -8,12 +8,8 @@ class InvalidRepoUrlError(RepoUrlsBaseError):
 
 
 class UnsupportedPlatformError(RepoUrlsBaseError):
-    @property
-    def supported_platforms(self):
-        return list(self._supported_platforms)
-
-    def __init__(self, url_string, platform, supported_platforms) -> None:
-        self._supported_platforms = supported_platforms
+    def __init__(self, url_string, host, supported_hosts) -> None:
+        self.supported_hosts = supported_hosts
         super().__init__(
             f"Unsupported version control host. Got: {host}. "
             f"Expected one of: {supported_hosts}. URL: {url_string}"

--- a/mozilla_repo_urls/errors.py
+++ b/mozilla_repo_urls/errors.py
@@ -15,6 +15,6 @@ class UnsupportedPlatformError(RepoUrlsBaseError):
     def __init__(self, url_string, platform, supported_platforms) -> None:
         self._supported_platforms = supported_platforms
         super().__init__(
-            f"Unsupported version control host. Got: {platform}. "
+            f"Unsupported version control host. Got: {host}. "
             f"Expected one of: {supported_platforms}. URL: {url_string}"
         )

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -9,7 +9,7 @@ for i, platform in enumerate(ADDITIONAL_PLATFORMS):
     giturlparse.platforms.PLATFORMS.insert(i, platform)
 
 
-_SUPPORTED_PLATFORMS = ("hgmo", "github")
+SUPPORTED_HOSTS = ("hgmo", "github")
 
 
 def parse(url_string):
@@ -21,7 +21,7 @@ def parse(url_string):
     if not parsed_url.valid:
         raise InvalidRepoUrlError(url_string)
 
-    if parsed_url.platform not in _SUPPORTED_PLATFORMS:
+    if parsed_url.platform not in SUPPORTED_HOSTS:
         """
         For error reporting purposes, the exception object includes the domain
         for each supported platform.
@@ -34,7 +34,7 @@ def parse(url_string):
                 for domains in [
                     platform[1].DOMAINS
                     for platform in giturlparse.platforms.PLATFORMS
-                    if platform[0] in _SUPPORTED_PLATFORMS
+                    if platform[0] in SUPPORTED_HOSTS
                 ]
                 for domain in domains
             ],

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -9,7 +9,7 @@ for i, platform in enumerate(ADDITIONAL_PLATFORMS):
     giturlparse.platforms.PLATFORMS.insert(i, platform)
 
 
-_SUPPORTED_PLAFORMS = ("hgmo", "github")
+_SUPPORTED_PLATFORMS = ("hgmo", "github")
 
 
 def parse(url_string):
@@ -21,7 +21,16 @@ def parse(url_string):
     if not parsed_url.valid:
         raise InvalidRepoUrlError(url_string)
 
-    if parsed_url.platform not in _SUPPORTED_PLAFORMS:
-        raise UnsupportedPlatformError(url_string, platform, _SUPPORTED_PLAFORMS)
-
+    if parsed_url.platform not in _SUPPORTED_PLATFORMS:
+        """
+        For error reporting purposes, the exception object includes the domain
+        for each supported platform.
+        """
+        raise UnsupportedPlatformError(url_string, parsed_url.host,
+                                       [domain
+                                        for domains in
+                                          [platform[1].DOMAINS
+                                           for platform in giturlparse.platforms.PLATFORMS
+                                           if platform[0] in _SUPPORTED_PLATFORMS]
+                                        for domain in domains])
     return parsed_url

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -9,7 +9,18 @@ for i, platform in enumerate(ADDITIONAL_PLATFORMS):
     giturlparse.platforms.PLATFORMS.insert(i, platform)
 
 
-SUPPORTED_HOSTS = ("hgmo", "github")
+_SUPPORTED_PLATFORMS = ("hgmo", "github")
+
+
+SUPPORTED_HOSTS = tuple(sorted([
+    host
+    for domains in [
+        platform[1].DOMAINS
+        for platform in giturlparse.platforms.PLATFORMS
+        if platform[0] in _SUPPORTED_PLATFORMS
+    ]
+    for host in domains
+]))
 
 
 def parse(url_string):
@@ -22,21 +33,11 @@ def parse(url_string):
         raise InvalidRepoUrlError(url_string)
 
     if parsed_url.platform not in SUPPORTED_HOSTS:
-        """
-        For error reporting purposes, the exception object includes the domain
-        for each supported platform.
-        """
+        # For error reporting purposes, the exception object includes the domain
+        # for each supported platform.
         raise UnsupportedPlatformError(
             url_string,
             parsed_url.host,
-            [
-                domain
-                for domains in [
-                    platform[1].DOMAINS
-                    for platform in giturlparse.platforms.PLATFORMS
-                    if platform[0] in SUPPORTED_HOSTS
-                ]
-                for domain in domains
-            ],
+            SUPPORTED_HOSTS
         )
     return parsed_url

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -36,7 +36,7 @@ def parse(url_string):
     if not parsed_url.valid:
         raise InvalidRepoUrlError(url_string)
 
-    if parsed_url.platform not in SUPPORTED_HOSTS:
+    if parsed_url.host not in SUPPORTED_HOSTS:
         # For error reporting purposes, the exception object includes the domain
         # for each supported platform.
         raise UnsupportedPlatformError(url_string, parsed_url.host, SUPPORTED_HOSTS)

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -12,15 +12,19 @@ for i, platform in enumerate(ADDITIONAL_PLATFORMS):
 _SUPPORTED_PLATFORMS = ("hgmo", "github")
 
 
-SUPPORTED_HOSTS = tuple(sorted([
-    host
-    for domains in [
-        platform[1].DOMAINS
-        for platform in giturlparse.platforms.PLATFORMS
-        if platform[0] in _SUPPORTED_PLATFORMS
-    ]
-    for host in domains
-]))
+SUPPORTED_HOSTS = tuple(
+    sorted(
+        [
+            host
+            for domains in [
+                platform[1].DOMAINS
+                for platform in giturlparse.platforms.PLATFORMS
+                if platform[0] in _SUPPORTED_PLATFORMS
+            ]
+            for host in domains
+        ]
+    )
+)
 
 
 def parse(url_string):
@@ -35,9 +39,5 @@ def parse(url_string):
     if parsed_url.platform not in SUPPORTED_HOSTS:
         # For error reporting purposes, the exception object includes the domain
         # for each supported platform.
-        raise UnsupportedPlatformError(
-            url_string,
-            parsed_url.host,
-            SUPPORTED_HOSTS
-        )
+        raise UnsupportedPlatformError(url_string, parsed_url.host, SUPPORTED_HOSTS)
     return parsed_url

--- a/mozilla_repo_urls/parser.py
+++ b/mozilla_repo_urls/parser.py
@@ -26,11 +26,17 @@ def parse(url_string):
         For error reporting purposes, the exception object includes the domain
         for each supported platform.
         """
-        raise UnsupportedPlatformError(url_string, parsed_url.host,
-                                       [domain
-                                        for domains in
-                                          [platform[1].DOMAINS
-                                           for platform in giturlparse.platforms.PLATFORMS
-                                           if platform[0] in _SUPPORTED_PLATFORMS]
-                                        for domain in domains])
+        raise UnsupportedPlatformError(
+            url_string,
+            parsed_url.host,
+            [
+                domain
+                for domains in [
+                    platform[1].DOMAINS
+                    for platform in giturlparse.platforms.PLATFORMS
+                    if platform[0] in _SUPPORTED_PLATFORMS
+                ]
+                for domain in domains
+            ],
+        )
     return parsed_url

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -2,7 +2,7 @@ from mozilla_repo_urls import parser
 
 
 def test_supported_hosts():
-    assert parser._SUPPORTED_HOSTS == (
+    assert parser.SUPPORTED_HOSTS == (
         "gist.github.com",
         "github.com",
         "hg.mozilla.org",

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -2,5 +2,8 @@ from mozilla_repo_urls import parser
 
 
 def test_supported_hosts():
-    assert parser._SUPPORTED_HOSTS == ("gist.github.com", "github.com", "hg.mozilla.org")
-
+    assert parser._SUPPORTED_HOSTS == (
+        "gist.github.com",
+        "github.com",
+        "hg.mozilla.org",
+    )

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,6 @@
+from mozilla_repo_urls import parser
+
+
+def test_supported_hosts():
+    assert parser._SUPPORTED_HOSTS == ("gist.github.com", "github.com", "hg.mozilla.org")
+


### PR DESCRIPTION
In parser.py, the UnsupportedPlatformError raised by parse() included `platform` rather than `parsed_url.platform`, leading to a misleading error message. This commit changes the error to use `parsed_url.host` instead, which is more helpful for diagnosing the error. It also changes `UnsupportedPlatformError` to take a list of supported platforms, which is helpful to the caller in printing out a helpful error message.