### PR TITLE
Fix equality to not raise exceptions when used with None or other types

### DIFF
--- a/mozilla_repo_urls/result.py
+++ b/mozilla_repo_urls/result.py
@@ -35,4 +35,7 @@ class RepoUrlParsed(giturlparse.result.GitUrlParsed):
         return f"repo:{self.host}/{self.repo_path}"
 
     def __eq__(self, other):
-        return self.normalized == other.normalized
+        if isinstance(other, RepoUrlParsed):
+            return self.normalized == other.normalized
+
+        return False

--- a/test/test_eq.py
+++ b/test/test_eq.py
@@ -8,34 +8,48 @@ from mozilla_repo_urls import parse
     (
         pytest.param(
             "https://github.com/mozilla/repo.git",
-            "https://github.com/mozilla/repo.git",
+            parse("https://github.com/mozilla/repo.git"),
             True,
         ),
         pytest.param(
             "https://hg.mozilla.org/mozilla-central",
-            "https://hg.mozilla.org/mozilla-central",
+            parse("https://hg.mozilla.org/mozilla-central"),
             True,
         ),
         pytest.param(
             "https://github.com/mozilla/repo.git",
-            "https://github.com/mozilla/repo2.git",
+            parse("https://github.com/mozilla/repo2.git"),
             False,
         ),
         pytest.param(
             "https://github.com/mozilla/repo.git",
-            "https://github.com/mozilla2/repo.git",
+            parse("https://github.com/mozilla2/repo.git"),
             False,
         ),
         pytest.param(
             "https://hg.mozilla.org/mozilla-central",
-            "https://github.com/mozilla/repo.git",
+            parse("https://github.com/mozilla/repo.git"),
+            False,
+        ),
+        pytest.param(
+            "https://hg.mozilla.org/mozilla-central",
+            None,
+            False,
+        ),
+        pytest.param(
+            "https://hg.mozilla.org/mozilla-central",
+            "https://hg.mozilla.org/mozilla-central",  # This is a str on purpose
+            False,
+        ),
+        pytest.param(
+            "https://hg.mozilla.org/mozilla-central",
+            42,
             False,
         ),
     ),
 )
 def test_equality(left, right, should_be_equal):
     left = parse(left)
-    right = parse(right)
 
     if should_be_equal:
         assert left == right


### PR DESCRIPTION
I've been writing too much rust and forgot that python's `__eq__` is called even when the type of `other` doesn't match ours.